### PR TITLE
Two-tier approach to overcome GitHub permission restriction

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,3 +1,8 @@
+# This workflow is triggered whenever "Caller Arm Virtual Hardware basic example" workflow is completed (which is called by PR).
+# This workflow ideally should be triggered also by PR, but forked PR has limited permissions which does not
+# allow to use `configure-aws-credentials` actions and using secrets.
+# It will update its status back to the caller PR as "Arm Virtual Hardware basic example" check name
+
 # This is a basic workflow to help you get started with Actions on CMSIS projects
 # See also https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/infrastructure-for-continuous-integration-tests
 #
@@ -10,14 +15,13 @@
 # - AWS_SECURITY_GROUP_ID       The id of the security group to add the EC2 instance to.
 # - AWS_SUBNET_ID               The id of the network subnet to connect the EC2 instance to.
 
-name: Arm Virtual Hardware basic example - github hosted - remote AWS via GH plugin
+name: Arm Virtual Hardware basic example
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    paths:
-      - .github/workflows/basic.yml
-      - basic/**/*
+  workflow_run:
+    workflows:
+      - Caller Arm Virtual Hardware basic example
+    types:
+      - completed
   workflow_dispatch:
 
 env:
@@ -30,8 +34,27 @@ env:
   AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
   AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
 jobs:
+  set_pending_status_to_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set a pending status to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "pending",
+              "context": "Arm Virtual Hardware basic example",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail
+
   ci_test:
     runs-on: ubuntu-latest
+    needs: set_pending_status_to_pr
     permissions:
       id-token: write
       contents: read
@@ -40,7 +63,37 @@ jobs:
       testbadge: ${{ steps.avh.outputs.badge }}
     steps:
     - name: Check out repository code
+      if: ${{ github.event.workflow_run.event == 'workflow_dispatch' }}
       uses: actions/checkout@v3
+
+    - name: Download workflow artifact
+      if: ${{ github.event.workflow.name == 'Caller Arm Virtual Hardware'}}
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: caller_virtual_hardware.yml
+        run_id: ${{ github.event.workflow_run.id }}
+
+    - name: Read the pr_num file
+      if: ${{ github.event.workflow.name == 'Caller Arm Virtual Hardware'}}
+      id: pr_num_reader
+      uses: juliangruber/read-file-action@v1.1.6
+      with:
+        path: ./pr_number/pr_number
+        trim: true
+
+    - name: Clone this repo
+      if: ${{ github.event.workflow.name == 'Caller Arm Virtual Hardware'}}
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Checkout PR
+      if: ${{ github.event.workflow.name == 'Caller Arm Virtual Hardware'}}
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      run: |
+        gh pr checkout ${{ steps.pr_num_reader.outputs.content }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
@@ -82,7 +135,6 @@ jobs:
         report_paths: basic/basic-*.xunit
       if: always()
 
-
   badge:
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -110,3 +162,43 @@ jobs:
           if git commit -m "Update badges for workflow basic.yml"; then
             git push
           fi
+
+  set_success_status_to_pr:
+    runs-on: ubuntu-latest
+    needs: ci_test
+    if: ${{ success() }}
+    steps:
+      - name: Set success status to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "success",
+              "context": "Arm Virtual Hardware basic example",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail
+
+  set_failure_status_to_pr:
+    runs-on: ubuntu-latest
+    needs: ci_test
+    if: ${{ failure() }}
+    steps:
+      - name: Set failure status to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_commit.id }} \
+            --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header 'content-type: application/json' \
+            --data '{
+              "state": "failure",
+              "context": "Arm Virtual Hardware basic example",
+              "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id	}}"
+              }' \
+            --fail

--- a/.github/workflows/caller-basic.yml
+++ b/.github/workflows/caller-basic.yml
@@ -1,0 +1,22 @@
+name: Caller Arm Virtual Hardware basic example
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    paths:
+      - .github/workflows/basic.yml
+      - basic/**/*
+jobs:
+  upload_pr_number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo -n $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/


### PR DESCRIPTION
Using a two-tier approach to overcome GitHub permission restriction on pull requested-based runs.

The caller_basic.yml is triggered by PRs (with limited permission if forked), it collects PR number to be passed to the called virtual_hardware.yml (this run has full permissions, e.g. to assume-role and consume secrets).

The Arm Virtual Hardware workflow will feedback on its status to the PR with a "Arm Virtual Hardware basic example" check name.

Caveat: The basic.yml workflow code is, by GH design, run from the base branch, not from the PR. So, changes on basic.yml file only take effect when merged to the base branch (e.g. main)